### PR TITLE
Fix current page header retrieval

### DIFF
--- a/GChartShortcode.php
+++ b/GChartShortcode.php
@@ -39,7 +39,7 @@ class GChartShortcode extends Shortcode
 
     public function process(ShortcodeInterface $sc) {
         // Get page header
-        $header = $this->grav['page']->header();
+        $header = $this->shortcode->getPage()->header();
         $header = new \Grav\Common\Page\Header((array) $header);
 
     	// Load overall Google Charts library


### PR DESCRIPTION
In modular pages, `$this->grav['page']` refers to the page being displayed (parent page), whereas we want to retrieve header from the currently processed sub-page.

Fortunately, the shortcode core plugin provides easy access to that!